### PR TITLE
refactor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests==2.22.0
-python-dateutil==2.8.1
 nltk==3.4.5


### PR DESCRIPTION
- no longer create intermediary .csv.bz2 files
- write orphan cases to their own output if they exist, instead of erroring
- checksum downloaded wiki history files
- reorganize project to use a single executor
- reorganize project to iterate on revisions instead of intermediary revision files