### PR TITLE
option to write to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ download every wikipedia edit
 [![status](https://github.com/DominicBurkart/wikipedia-revisions/workflows/Python%20application/badge.svg)](https://github.com/DominicBurkart/wikipedia-revisions/actions?query=is%3Acompleted+branch%3Amaster)
 
 
-This script downloads every revision to wikipedia and outputs them into a single bz2-zipped csv file.
+This script downloads every revision to wikipedia. It can output the revisions into a [sqlalchemy-supported database](https://docs.sqlalchemy.org/en/13/dialects/) or into single bz2-zipped csv file.
 
 Revisions are output with the following fields:
-- "id": the revision id, numeric
-- "parent": parent revision id (if it exists), numeric
-- "timestamp": timestamp with timezone
-- "text": complete article text after the revision is applied, in wikipedia markdown
+- `id`: the revision id, numeric
+- `parent_id`: parent revision id (if it exists), numeric
+- `page_id`: id of page, numeric
+- `page_name`: name of page
+- `page_ns`: page namespace, numeric
+- `timestamp`: timestamp with timezone
+- `contributor_id`: id of contributor, numeric
+- `contributor_name`: screen name of contributor
+- `contributor_ip`: ip addresss of contributor
+- `text`: complete article text after the revision is applied, string in wikipedia markdown
+- `comment`: comment
+
+All fields except id and timestamp may be blank.
 
 System requirements:
 - 4gb memory
@@ -18,18 +27,48 @@ System requirements:
 - python 3 & pip pre-installed
 
 I wrote a [blog post](https://dominicburkart.com/blog/2020/big_data_and_small_computers.html) on some of the project 
-goals and technical choices.
+goals and technical choices. PyPy is supported while outputting to a csv,
+but not while outputting to a database.
 
+## Installation
 
-Example use:
-```sh 
+For writing to a bz2-compressed csv file:
+```sh
 git clone https://github.com/DominicBurkart/wikipedia-revisions
 cd wikipedia-revisions
 pip3 install -r requirements.txt
+```
+
+For writing to a database:
+```sh
+git clone https://github.com/DominicBurkart/wikipedia-revisions
+cd wikipedia-revisions
+pip3 install -r database_requirements.txt
+```
+
+## Use
+
+Use `--help` to see the available options:
+```sh
+python3 wikipedia_download.py --help
+```
+
+Output all revisions into a giant bz2-zipped csv:
+```sh 
 python3 wikipedia_download.py
 ```
 
-You can also pass some parameters to the script, visible on its --help:
+Use a wikipedia dump from a specific date:
 ```sh
-python3 wikipedia_download.py --help
+python3 wikipedia_download.py --date 20200101
+```
+
+Output to postgres server named "wikipedia-revisions" waiting at port 5432:
+```sh
+python3 wikipedia_download.py --database
+```
+
+To set the database url:
+```sh
+python3 wikipedia_download.py --database --database-url postgres://postgres@localhost:5432/wikipedia-revisions
 ```

--- a/database_requirements.txt
+++ b/database_requirements.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+python-dateutil==2.8.1
+psycopg2==2.8.5
+SQLAlchemy==1.3.16
+SQLAlchemy-Utils==0.36.3


### PR DESCRIPTION
Use sqlalchemy to write directly to a database, instead of writing to a csv.bz2 file. Any sqlalchemy-supported dialect should be usable. Manually tested with postgres on mac.
- add special requirements file for writing database
- restructure iterative parsing
- update readme & `--help`