### PR TITLE
avoid hanging indefinitely if result() doesn't correctly fire

### DIFF
--- a/wikipedia_revisions/utils.py
+++ b/wikipedia_revisions/utils.py
@@ -2,11 +2,18 @@ from typing import Tuple, Iterable, Callable, Generator, TypeVar, Any
 import threading
 import queue
 import multiprocessing
-from concurrent.futures import Executor, ProcessPoolExecutor, ThreadPoolExecutor, Future
+from concurrent.futures import (
+    Executor,
+    ProcessPoolExecutor,
+    ThreadPoolExecutor,
+    Future,
+    wait,
+    FIRST_COMPLETED,
+    ALL_COMPLETED,
+)
 from enum import Enum
 import datetime
 from functools import partial
-from collections import deque
 import os
 
 import dill
@@ -183,16 +190,28 @@ def merge_iterators(
             executor_kwargs["max_workers"] = chunk_size
 
         with Executor(**executor_kwargs) as executor:
-            active_futures = deque()
+            active_futures = set()
             for iterator_function in iterator_functions:
                 serialized_iterator = dill.dumps(iterator_function)
                 future = executor.submit(_iter_spanner, serialized_iterator, queue)
                 if chunk_size != -1:
-                    active_futures.append(future)
+                    active_futures.add(future)
                     while len(active_futures) >= chunk_size:
-                        active_futures.popleft().result()
-            if len(active_futures) > 0:
-                active_futures.popleft().result()
+                        completed_futures, active_futures = wait(
+                            active_futures,
+                            return_when=FIRST_COMPLETED,
+                            timeout=(0.1 * len(active_futures)) + 10,
+                        )
+                        for future in completed_futures:
+                            future.result()
+            while len(active_futures) > 0:
+                completed_futures, active_futures = wait(
+                    active_futures,
+                    return_when=ALL_COMPLETED,
+                    timeout=(0.1 * len(active_futures)) + 45,
+                )
+                for future in completed_futures:
+                    future.result()
 
     results_queue = multiprocessing.Manager().Queue(maxsize=buffer)
     with ThreadPoolExecutor(max_workers=1) as executor:
@@ -219,22 +238,22 @@ def merge_iterators(
 
 def test_merge_iterators():
     def gen1():
-        for x in range(10):
+        for x in range(1000):
             yield x
 
     def gen2():
-        for y in range(10, 20):
+        for y in range(1000, 2000):
             yield y
 
     assert set(merge_iterators((gen1, gen2), 1, 1, PoolExecutor.Process)) == set(
-        range(20)
+        range(2000)
     )
-    assert len(list(merge_iterators((gen1, gen2), 1, 1, PoolExecutor.Process))) == 20
+    assert len(list(merge_iterators((gen1, gen2), 1, 1, PoolExecutor.Process))) == 2000
 
     assert set(merge_iterators([gen1, gen2], 1, 1, PoolExecutor.Thread)) == set(
-        range(20)
+        range(2000)
     )
-    assert len(list(merge_iterators([gen1, gen2], 1, 1, PoolExecutor.Thread))) == 20
+    assert len(list(merge_iterators([gen1, gen2], 1, 1, PoolExecutor.Thread))) == 2000
 
 
 class LazyList:


### PR DESCRIPTION
issue: https://github.com/DominicBurkart/wikipedia-revisions/issues/18

I believe that the issue is that some process is hanging in the `merge_iterators` function. The two likely sites of error are thus:
- the multiprocessing queue blocking, or not correcting sending information, or
- the `future.result()` function hanging indefinitely.

This bug appeared in PyPy (no replication attempt with CPython has yet been made). I have had issues where `.result()` hangs when it should return before, so my intuition is that the result is where we're having an issue. I refactored to use `concurrent.futures.wait()` with a timeout instead. I will now test this branch on the downstream project and, if it fixes the hanging issue, merge it.


### edit: conclusion
It seems that the issue seen in the downstream program is not caused by a hanging `.result()`. Since the issue requires more care, I am temporarily disabling the use of processes to join multiple iterators until I have time to locate and fix the issue. I will open a new PR then.
